### PR TITLE
Update config.plist

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1177,6 +1177,13 @@
                 <false/>
             </dict>
             <key>ReservedMemory</key>
+            <key>RtVariables</key>
+                <dict>
+                    <key>CsrActiveConfig</key>
+                    <string>0x67</string>
+                    <key>BooterConfig</key>
+                    <string>0x28</string>
+                </dict>
             <array/>
         </dict>
     </dict>


### PR DESCRIPTION
Fixes issue with Ethernet controller (I219-V) which is used by the Intel Nuc8i5BEH during the installation process.

Sources: 
* https://www.tonymacx86.com/threads/solved-appleigb-and-intelmausi-kext-issue.260831/
* https://www.tonymacx86.com/threads/help-ethernet-connection-i219-v-not-working-with-macos-12.320149/